### PR TITLE
Fix: Recipe modal close button uses Bootstrap 4 attribute on Bootstrap 5 page

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,9 +137,7 @@ layout: default
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title" id="recipeModalLabel">{{ recipe.title }}</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
                         <img src="{{ recipe.images[0].path | relative_url }}" alt="{{ recipe.images[0].alt }}" class="img-fluid" />


### PR DESCRIPTION
## Summary

- Changed close button from Bootstrap 4 `data-dismiss="modal"` to Bootstrap 5 `data-bs-dismiss="modal"`
- Updated button markup to use `btn-close` class (Bootstrap 5 standard) in place of the legacy `close` class with inline `&times;` span

## Test Plan

- [ ] Open https://rickmanley-nc.github.io/NFG/ after deploy
- [ ] Click any recipe card to open the modal
- [ ] Click the close button — verify the modal closes
- [ ] Verify the close button renders correctly (Bootstrap 5 styled ×)

Closes #3
