### PR TITLE
Fix double document and empty mobile nav drawer

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,8 +5,16 @@
             <img src="{{ '/assets/img/bear-removebg.png' | relative_url }}" />
         </a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
-            Menu
+            Explore
             <i class="fas fa-bars ms-1"></i>
         </button>
+        <div class="collapse navbar-collapse" id="navbarResponsive">
+            <ul class="navbar-nav text-uppercase ms-auto py-4 py-lg-0">
+                {% assign categories = "starters,mains,desserts,cocktails,miscellaneous,family" | split: "," %}
+                {% for category in categories %}
+                    <li class="nav-item"><a class="nav-link" href="#{{ category }}">{{ category | capitalize }}</a></li>
+                {% endfor %}
+            </ul>
+        </div>
     </div>
 </nav>

--- a/index.html
+++ b/index.html
@@ -2,43 +2,6 @@
 layout: default
 ---
 
-<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-        <meta name="description" content="" />
-        <meta name="author" content="" />
-        <!-- Favicon-->
-        <link rel="icon" type="image/x-icon" href="assets/img/bear-removebg.png" />
-        <!-- Font Awesome icons (free version)-->
-        <script src="https://use.fontawesome.com/releases/v6.1.0/js/all.js" crossorigin="anonymous"></script>
-        <!-- Google fonts-->
-        <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css" />
-        <link href="https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700" rel="stylesheet" type="text/css" />
-        <!-- Core theme CSS (includes Bootstrap)-->
-        <link href="css/styles.css" rel="stylesheet" />
-    </head>
-    <body id="page-top">
-        <!-- Navigation-->
-        <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
-            <div class="container">
-                <a class="navbar-brand" href="#page-top"><img src="assets/img/bear-removebg.png" alt="..." /></a>
-                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
-                    Explore
-                    <i class="fas fa-bars ms-1"></i>
-                </button>
-                <div class="collapse navbar-collapse" id="navbarResponsive">
-                    <ul class="navbar-nav text-uppercase ms-auto py-4 py-lg-0">
-                        {% assign categories = "starters,mains,desserts,cocktails,miscellaneous,family" | split: "," %}
-                        {% for category in categories %}
-                            <li class="nav-item"><a class="nav-link" href="#{{ category }}">{{ category | capitalize }}</a></li>
-                        {% endfor %}
-                    </ul>
-                </div>
-            </div>
-        </nav>
-
         <!-- Masthead-->
         <header class="masthead">
             <div class="container">
@@ -182,9 +145,3 @@ layout: default
             </div>
         </div>
         {% endfor %}
-        <!-- Bootstrap core JS-->
-        <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.bundle.min.js"></script>
-        <script src="js/scripts.js"></script>
-    </body>
-</html>


### PR DESCRIPTION
## Summary

- `index.html` declared both `layout: default` and a full `<!DOCTYPE html>` scaffold — Jekyll injected the complete document as `{{ content }}` inside `default.html`'s body, producing two nested HTML documents and loading all scripts (Bootstrap, Font Awesome, scripts.js) twice
- Strips the HTML scaffold from `index.html` so it is content-only; `_layouts/default.html` provides the outer `<html>/<head>/<body>` wrapper as intended
- Moves the complete navbar (including the dynamic `#navbarResponsive` collapse div with category nav links) from `index.html` into `_includes/header.html`, which `default.html` already includes via `{% include header.html %}` — the previous `header.html` had only the brand and toggler with no collapse div, so the mobile drawer opened to an empty space

## Test Plan

- [ ] View page source — only one `<!DOCTYPE html>` present
- [ ] All scripts (Bootstrap, Font Awesome, scripts.js) appear exactly once
- [ ] Desktop navbar renders with all section links (Starters, Mains, Desserts, Cocktails, Miscellaneous, Family)
- [ ] Mobile: hamburger button opens drawer with nav links
- [ ] Masthead, recipe grid, Family section, and modals all render correctly

Closes #7
Closes #9
