### PR TITLE
Fix baseurl for GitHub Pages project site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: Nelson Farm and Grill
 description: Family recipes and cooking adventures
-baseurl: ""
-url: ""
+baseurl: "/NFG"
+url: "https://rickmanley-nc.github.io"
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
## Summary

- `_config.yml` had `baseurl: ""` and `url: ""` but the site is served at `https://rickmanley-nc.github.io/NFG/`
- Jekyll's `relative_url` filter prepends `baseurl` to asset paths — with an empty baseurl, `/css/styles.css` resolves to `https://rickmanley-nc.github.io/css/styles.css` (404) instead of `https://rickmanley-nc.github.io/NFG/css/styles.css`
- All stylesheet, script, and image paths in `_layouts/default.html` use `relative_url` and were silently broken — the previous double-document structure masked this because `index.html`'s own `<head>` loaded assets via bare relative paths that bypassed the filter
- Sets `baseurl: "/NFG"` and `url: "https://rickmanley-nc.github.io"` per the Jekyll docs for GitHub Pages project sites

## Test Plan

- [ ] Page loads with full styling (navbar, masthead background image, Bootstrap grid)
- [ ] Favicon loads
- [ ] Font Awesome icons appear
- [ ] scripts.js loads (navbar shrink on scroll works)
