### PR TITLE
Fix: recipe card image URLs broken after baseurl was set

### DIFF
--- a/_includes/recipe-card.html
+++ b/_includes/recipe-card.html
@@ -2,7 +2,7 @@
     <div class="portfolio-item">
         <a class="portfolio-link" data-bs-toggle="modal" href="#recipe-{{ recipe.slug | default: recipe.title | slugify }}">
             {% if recipe.images %}
-                <img class="img-fluid" src="{{ site.url }}{{ recipe.images[0].path }}" alt="{{ recipe.images[0].alt }}" />
+                <img class="img-fluid" src="{{ recipe.images[0].path | relative_url }}" alt="{{ recipe.images[0].alt }}" />
             {% endif %}
         </a>
         <div class="portfolio-caption" style="background-color: rgba(0, 0, 0, 0.5); padding: 10px; border-radius: 5px;">


### PR DESCRIPTION
## Summary

- `recipe-card.html` used `{{ site.url }}{{ recipe.images[0].path }}` to construct recipe card image URLs
- With `url: "https://rickmanley-nc.github.io"` now set in `_config.yml`, this produces a malformed path: `https://rickmanley-nc.github.io/assets/img/...` — missing the `/NFG` baseurl prefix and missing the slash separator between `site.url` and the path
- Replaced with `{{ recipe.images[0].path | relative_url }}`, which prepends `site.baseurl` (`/NFG`) and produces the correct path `/NFG/assets/img/...` — consistent with how all other asset paths are resolved in this project

## Test Plan

- [ ] Recipe grid images load on the live site (no broken image icons)
- [ ] Inspect image `src` attributes — should resolve to `/NFG/assets/img/portfolio/...`

Closes #28
