### PR TITLE
Fix: upgrade Bootstrap JS from 5.3.0-alpha1 to 5.3.8 stable

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,7 +24,7 @@
         {% include footer.html %}
         
         <!-- Bootstrap core JS-->
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js" integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
         <!-- Core theme JS-->
         <script src="{{ '/js/scripts.js' | relative_url }}"></script>
     </body>


### PR DESCRIPTION
## Summary

- Bootstrap JS CDN in `_layouts/default.html` was pinned to `5.3.0-alpha1`, a pre-release version never intended for production use
- Bootstrap 4.5.2 was the third version previously loaded from the old `index.html` scaffold; it was removed when the double-document structure was fixed in #36
- Updates Bootstrap JS to `5.3.8` (current stable), with updated SRI integrity hash
- `css/styles.css` bundles Bootstrap 5.1.3 from the Start Bootstrap Agency theme — 5.1.x and 5.3.x are minor-version compatible; all Bootstrap 5 component APIs and class names are stable across this range

## Test Plan

- [ ] Modals open and close correctly
- [ ] Navbar collapse works on mobile
- [ ] ScrollSpy scroll behavior functions
- [ ] No console errors related to Bootstrap

Closes #30
Closes #8
