### PR TITLE
Fix: recipe detail pages — add layout and grouped ingredient rendering

### DIFF
--- a/_layouts/recipe.html
+++ b/_layouts/recipe.html
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 <div class="modal-content">
     <div class="close-modal" data-bs-dismiss="modal">
         <img src="{{ '/assets/img/close-icon.svg' | relative_url }}" alt="Close modal" />
@@ -11,11 +14,11 @@
                     {% if page.subtitle %}
                         <p class="item-intro text-muted">{{ page.subtitle }}</p>
                     {% endif %}
-                    
+
                     {% if page.images %}
                         <img class="img-fluid d-block mx-auto" src="{{ page.images[0].path | relative_url }}" alt="{{ page.images[0].alt }}" />
                     {% endif %}
-                    
+
                     <div class="recipe-meta">
                         {% if page.prep_time %}
                             <p><strong>Prep Time:</strong> {{ page.prep_time }}</p>
@@ -30,15 +33,27 @@
 
                     {% if page.ingredients %}
                         <h3>Ingredients</h3>
-                        <ul class="ingredients-list">
-                        {% for ingredient in page.ingredients %}
-                            <li>
-                                {% if ingredient.amount %}{{ ingredient.amount }}{% endif %}
-                                {% if ingredient.unit %}{{ ingredient.unit }}{% endif %}
-                                {{ ingredient.item }}
-                            </li>
-                        {% endfor %}
-                        </ul>
+                        {% assign first_ingredient = page.ingredients | first %}
+                        {% if first_ingredient.group %}
+                            {% for ingredient_group in page.ingredients %}
+                                <h5>{{ ingredient_group.group }}</h5>
+                                <ul class="ingredients-list">
+                                {% for item in ingredient_group.items %}
+                                    <li>{{ item.amount }}{% if item.unit %} {{ item.unit }}{% endif %} {{ item.item }}{% if item.note %} — {{ item.note }}{% endif %}</li>
+                                {% endfor %}
+                                </ul>
+                            {% endfor %}
+                        {% else %}
+                            <ul class="ingredients-list">
+                            {% for ingredient in page.ingredients %}
+                                <li>
+                                    {% if ingredient.amount %}{{ ingredient.amount }}{% endif %}
+                                    {% if ingredient.unit %}{{ ingredient.unit }}{% endif %}
+                                    {{ ingredient.item }}
+                                </li>
+                            {% endfor %}
+                            </ul>
+                        {% endif %}
                     {% endif %}
 
                     {% if page.instructions %}


### PR DESCRIPTION
## Summary

- `_layouts/recipe.html` had no front matter, so Jekyll rendered recipe detail pages (`/recipes/<slug>/`) as bare, unstyled HTML fragments — no navbar, no CSS, no footer
- Added `layout: default` front matter to wrap recipe pages in `default.html`
- The ingredient loop iterated `page.ingredients` flat, treating each entry as `{ amount, unit, item }`. All current recipes use a grouped structure (`{ group, items: [...] }`), so the ingredient list always rendered empty
- Fixed the ingredient loop to check for grouped structure first (matching the pattern already used in `index.html`'s modal template), with a flat fallback for ungrouped recipes

## Test Plan

- [ ] Navigate directly to a recipe URL (e.g. `/NFG/recipes/brussels-sprouts-salad/`) — page should render with full navbar, styling, and footer
- [ ] Ingredient list renders with group headings and items for grouped recipes
- [ ] Ingredient list renders as a flat list for ungrouped recipes

Closes #11
Closes #12
