### PR TITLE
Fix: remove family from recipe grid loop — eliminates duplicate id and empty section

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ layout: default
         </header>
 
         <!-- Recipe Grid-->
-        {% assign categories = "starters,mains,desserts,cocktails,miscellaneous,family" | split: "," %}
+        {% assign categories = "starters,mains,desserts,cocktails,miscellaneous" | split: "," %}
         {% for category in categories %}
             <section class="page-section bg-dark bg-gradient" id="{{ category }}">
                 <div class="container">
@@ -30,8 +30,6 @@ layout: default
                                     Sip & Savor
                                 {% when 'miscellaneous' %}
                                     Miscellaneous
-                                {% when 'family' %}
-                                    The Family
                             {% endcase %}
                         </h3>
                     </div>


### PR DESCRIPTION
## Summary

- The recipe grid loop in `index.html` included `family` in its categories list, generating `<section id="family">` for a recipe grid that always rendered empty (no recipes have `category: family`)
- This created a duplicate `id="family"` — the loop section and the hardcoded family member profiles section both had the same id; browsers navigated to the first match (the empty recipe grid) instead of the family profiles
- Removed `family` from the recipe grid categories loop — the hardcoded family members section retains `id="family"`, and the "Family" nav link now correctly reaches it
- Also removed the unused `{% when 'family' %}` case from the section subheading template

## Test Plan

- [ ] "Family" nav link scrolls to the family member profiles section
- [ ] No empty "Family" recipe grid section appears on the page
- [ ] No duplicate `id="family"` in rendered HTML

Closes #10
Closes #35
