### PR TITLE
Fix: unique modal label IDs, image guard, remove deprecated role=document

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,15 +93,17 @@ layout: default
         </section>
 
         {% for recipe in site.recipes %}
-        <div class="modal fade" id="recipe-{{ recipe.slug | default: recipe.title | slugify }}" tabindex="-1" role="dialog" aria-labelledby="recipeModalLabel" aria-hidden="true">
-            <div class="modal-dialog" role="document">
+        <div class="modal fade" id="recipe-{{ recipe.slug | default: recipe.title | slugify }}" tabindex="-1" aria-labelledby="recipeLabel-{{ recipe.slug | default: recipe.title | slugify }}" aria-hidden="true">
+            <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h5 class="modal-title" id="recipeModalLabel">{{ recipe.title }}</h5>
+                        <h5 class="modal-title" id="recipeLabel-{{ recipe.slug | default: recipe.title | slugify }}">{{ recipe.title }}</h5>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
+                        {% if recipe.images %}
                         <img src="{{ recipe.images[0].path | relative_url }}" alt="{{ recipe.images[0].alt }}" class="img-fluid" />
+                        {% endif %}
                         <h5>Ingredients:</h5>
                         {% assign first_ingredient = recipe.ingredients | first %}
                         {% if first_ingredient.group %}


### PR DESCRIPTION
## Summary

- Makes each recipe modal's `aria-labelledby` and modal title `id` unique per recipe (was `recipeModalLabel` for all 16 modals — screen readers were announcing the wrong recipe title for every modal)
- Wraps the modal body `<img>` in `{% if recipe.images %}` guard to prevent a broken `<img>` tag being rendered for recipes that have no images defined
- Removes deprecated Bootstrap 4 `role="document"` attribute from `.modal-dialog` elements

## Test Plan

- [ ] Opening each recipe modal announces the correct recipe title to screen readers (verify `aria-labelledby` points to the correct `id` in the DOM)
- [ ] Opening a modal for a recipe with no images defined renders no broken `<img>` tag in the modal body
- [ ] Opening a modal for a recipe with images defined still displays the image correctly
- [ ] No `role="document"` attribute present on any `.modal-dialog` element in rendered HTML

Closes #16
Closes #17
Closes #23
