### PR TITLE
Fix: footer styling, broken images, placeholder content, copyright year

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,5 @@
-<footer>
+<footer class="footer">
     <div class="container">
-        <p class="text-muted">&copy; 2025 Nelson Farm and Grill. All rights reserved.</p>
+        <p class="text-muted">&copy; {{ 'now' | date: '%Y' }} Nelson Farm and Grill. All rights reserved.</p>
     </div>
 </footer>

--- a/_recipes/butternut-squash-turkey-chili.md
+++ b/_recipes/butternut-squash-turkey-chili.md
@@ -1,7 +1,7 @@
 ---
 layout: recipe
 title: Butternut Squash and Turkey Chili
-subtitle: Category - Meal Prep
+subtitle: Hearty fall chili — great for meal prep
 category: mains
 prep_time: 20 minutes
 cook_time: 25 minutes

--- a/_recipes/champagne-punch.md
+++ b/_recipes/champagne-punch.md
@@ -5,10 +5,6 @@ subtitle: Champagne over Prosecco
 category: cocktails
 prep_time: 10 minutes
 servings: 1
-images:
-  - path: assets/img/portfolio/champagne-punch.jpg
-    alt: Champagne Punch
-    note: Placeholder - Add image of champagne punch cocktail
 ingredients:
   - group: Honey Syrup
     items:

--- a/_recipes/egg-roll-bowl.md
+++ b/_recipes/egg-roll-bowl.md
@@ -7,7 +7,7 @@ prep_time: 15 minutes
 cook_time: 25 minutes
 servings: 4-6
 images:
-  - path: assets/img/portfolio/egg-roll-bowl.jpg
+  - path: assets/img/portfolio/Egg-Roll-in-a-Bowl-fixed.jpg
     alt: Egg Roll in a Bowl
 ingredients:
   - group: Main Ingredients

--- a/_recipes/korean-bbq-sauce.md
+++ b/_recipes/korean-bbq-sauce.md
@@ -7,10 +7,6 @@ prep_time: 5 minutes
 cook_time: 5 minutes
 servings: About 1 cup
 spice_level: Medium-Hot
-images:
-  - path: assets/img/portfolio/korean-bbq-sauce.jpg
-    alt: Korean BBQ Sauce
-    note: Placeholder - Add image of Korean BBQ sauce
 ingredients:
   - group: Base Ingredients
     items:

--- a/_recipes/meringue-cookies.md
+++ b/_recipes/meringue-cookies.md
@@ -6,10 +6,6 @@ prep_time: 20 minutes
 cook_time: 1 hour
 cooling_time: 1-2 hours
 servings: 24 cookies
-images:
-  - path: assets/img/portfolio/placeholder-meringue-cookies.jpg
-    alt: Meringue Cookies
-    note: Placeholder - Add image of meringue cookies
 ingredients:
   - group: Main Ingredients
     items:

--- a/_recipes/simple-salt-brine.md
+++ b/_recipes/simple-salt-brine.md
@@ -5,10 +5,6 @@ category: miscellaneous
 prep_time: 5 minutes
 brine_time: 2-3 hours
 servings: Enough for 2-3 pounds of chicken wings
-images:
-  - path: assets/img/portfolio/simple-salt-brine.jpg
-    alt: Simple Salt Brine
-    note: Placeholder - Add image of brine preparation
 ingredients:
   - group: Brine Base
     items:

--- a/_recipes/teriyaki-sauce.md
+++ b/_recipes/teriyaki-sauce.md
@@ -6,10 +6,6 @@ category: miscellaneous
 prep_time: 5 minutes
 cook_time: 10 minutes
 servings: About 1.5 cups
-images:
-  - path: assets/img/portfolio/teriyaki-sauce.jpg
-    alt: Teriyaki Sauce
-    note: Placeholder - Add image of teriyaki sauce
 ingredients:
   - group: Sauce Base
     items:

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@ layout: default
                                 {% when 'cocktails' %}
                                     Sip & Savor
                                 {% when 'miscellaneous' %}
-                                    Miscellaneous
+                                    From the Pantry
                             {% endcase %}
                         </h3>
                     </div>


### PR DESCRIPTION
## Summary

- **#18** `_includes/footer.html`: add `class="footer"` so the `.footer` CSS selector applies — footer was rendering with default browser styles
- **#33** `_includes/footer.html`: replace hardcoded `2025` with `{{ 'now' | date: '%Y' }}` — copyright year now updates automatically
- **#44** `_recipes/egg-roll-bowl.md`: fix `path:` to match actual file `Egg-Roll-in-a-Bowl-fixed.jpg`
- **#45** `_recipes/champagne-punch.md`, `korean-bbq-sauce.md`, `meringue-cookies.md`, `simple-salt-brine.md`, `teriyaki-sauce.md`: remove `images:` front matter where no file exists — prevents broken `<img>` tags from rendering
- **#20** `_recipes/butternut-squash-turkey-chili.md`: replace placeholder subtitle `Category - Meal Prep`
- **#19** `index.html`: replace `Miscellaneous` subheading (identical to section heading) with `From the Pantry`

Closes #18, closes #33, closes #44, closes #45, closes #20, closes #19