### PR TITLE
Fix: accessibility, hover overlay, caption styles, image dimensions

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
 <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
     <div class="container">
         <a class="navbar-brand" href="#page-top">
-            <img src="{{ '/assets/img/bear-removebg.png' | relative_url }}" />
+            <img src="{{ '/assets/img/bear-removebg.png' | relative_url }}" alt="Nelson Farm and Grill" width="498" height="501" />
         </a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
             Explore

--- a/_includes/recipe-card.html
+++ b/_includes/recipe-card.html
@@ -2,13 +2,13 @@
     <div class="portfolio-item">
         <a class="portfolio-link" data-bs-toggle="modal" href="#recipe-{{ recipe.slug | default: recipe.title | slugify }}">
             {% if recipe.images %}
-                <img class="img-fluid" src="{{ recipe.images[0].path | relative_url }}" alt="{{ recipe.images[0].alt }}" />
+                <img class="img-fluid" src="{{ recipe.images[0].path | relative_url }}" alt="{{ recipe.images[0].alt }}" width="600" height="450" />
             {% endif %}
         </a>
-        <div class="portfolio-caption" style="background-color: rgba(0, 0, 0, 0.5); padding: 10px; border-radius: 5px;">
-            <div class="portfolio-caption-heading" style="color: yellow;">{{ recipe.title }}</div>
+        <div class="portfolio-caption">
+            <div class="portfolio-caption-heading">{{ recipe.title }}</div>
             {% if recipe.subtitle %}
-                <div class="portfolio-caption-subheading text-muted">{{ recipe.subtitle }}</div>
+                <div class="portfolio-caption-subheading">{{ recipe.subtitle }}</div>
             {% endif %}
         </div>
     </div>

--- a/css/styles.css
+++ b/css/styles.css
@@ -11449,48 +11449,51 @@ header.masthead .masthead-heading {
     margin-bottom: 4rem;
   }
 }
-#portfolio .portfolio-item {
+.portfolio-item {
   max-width: 26rem;
   margin-left: auto;
   margin-right: auto;
 }
-#portfolio .portfolio-item .portfolio-link {
+.portfolio-item .portfolio-link {
   position: relative;
   display: block;
   margin: 0 auto;
 }
-#portfolio .portfolio-item .portfolio-link .portfolio-hover {
+.portfolio-item .portfolio-link .portfolio-hover {
   display: flex;
   position: absolute;
   width: 100%;
   height: 100%;
-  background: rgba(255, 204, 255, 0.8);
+  background: rgba(255, 200, 0, 0.8);
   align-items: center;
   justify-content: center;
   opacity: 0;
   transition: opacity ease-in-out 0.25s;
 }
-#portfolio .portfolio-item .portfolio-link .portfolio-hover .portfolio-hover-content {
+.portfolio-item .portfolio-link .portfolio-hover .portfolio-hover-content {
   font-size: 1.25rem;
   color: white;
 }
-#portfolio .portfolio-item .portfolio-link:hover .portfolio-hover {
+.portfolio-item .portfolio-link:hover .portfolio-hover {
   opacity: 1;
 }
-#portfolio .portfolio-item .portfolio-caption {
-  padding: 1.5rem;
+.portfolio-item .portfolio-caption {
+  padding: 10px;
   text-align: center;
-  background-color: #b5b5b5;
+  background-color: rgba(0, 0, 0, 0.5);
+  border-radius: 5px;
 }
-#portfolio .portfolio-item .portfolio-caption .portfolio-caption-heading {
+.portfolio-item .portfolio-caption .portfolio-caption-heading {
   font-size: 1.5rem;
   font-family: "Montserrat", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-weight: 700;
   margin-bottom: 0;
+  color: #ffc800;
 }
-#portfolio .portfolio-item .portfolio-caption .portfolio-caption-subheading {
+.portfolio-item .portfolio-caption .portfolio-caption-subheading {
   font-style: italic;
   font-family: "Roboto Slab", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  color: rgba(255, 255, 255, 0.9);
 }
 
 .portfolio-modal .modal-dialog {

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ layout: default
         <header class="masthead">
             <div class="container">
                 <div class="masthead-subheading">Welcome Home...</div>
-                <div class="masthead-heading text-uppercase">Nelson Farm and Grill</div>
+                <h1 class="masthead-heading text-uppercase">Nelson Farm and Grill</h1>
                 <a class="btn btn-primary btn-xl text-uppercase" href="#starters">View Recipes</a>
             </div>
         </header>
@@ -53,7 +53,7 @@ layout: default
                 <div class="row">
                     <div class="col-lg-3">
                         <div class="team-member">
-                            <img class="mx-auto rounded-circle" src="assets/img/team/ricky.png" alt="Ricky Nelson" />
+                            <img class="mx-auto rounded-circle" src="assets/img/team/ricky.png" alt="Ricky Nelson" width="500" height="500" />
                             <h4>Ricky Nelson</h4>
                             <p class="text-muted">Pops</p>
                             <a class="btn btn-dark btn-social mx-2" href="https://www.linkedin.com/in/ricky-nelson/" target="_blank" rel="noopener noreferrer" aria-label="Ricky Nelson LinkedIn Profile"><i class="fab fa-linkedin-in"></i></a>
@@ -61,7 +61,7 @@ layout: default
                     </div>
                     <div class="col-lg-3">
                         <div class="team-member">
-                            <img class="mx-auto rounded-circle" src="assets/img/team/sara.jpg" alt="SaraLu" />
+                            <img class="mx-auto rounded-circle" src="assets/img/team/sara.jpg" alt="SaraLu" width="500" height="500" />
                             <h4>SaraLu</h4>
                             <p class="text-muted">Lu</p>
                             <a class="btn btn-dark btn-social mx-2" href="#!" aria-label="SaraLu LinkedIn Profile"><i class="fab fa-linkedin-in"></i></a>
@@ -69,7 +69,7 @@ layout: default
                     </div>
                     <div class="col-lg-3">
                         <div class="team-member">
-                            <img class="mx-auto rounded-circle" src="assets/img/team/bear.jpg" alt="Bear" />
+                            <img class="mx-auto rounded-circle" src="assets/img/team/bear.jpg" alt="Bear" width="500" height="500" />
                             <h4>Bear</h4>
                             <p class="text-muted">Dooters</p>
                             <a class="btn btn-dark btn-social mx-2" href="#!" aria-label="Bear Instagram Profile"><i class="fab fa-instagram"></i></a>
@@ -77,7 +77,7 @@ layout: default
                     </div>
                     <div class="col-lg-3">
                         <div class="team-member">
-                            <img class="mx-auto rounded-circle" src="assets/img/team/bitty.jpg" alt="Bitty" />
+                            <img class="mx-auto rounded-circle" src="assets/img/team/bitty.jpg" alt="Bitty" width="500" height="500" />
                             <h4>Bitty</h4>
                             <p class="text-muted">Itty Bitty Kitty</p>
                             <a class="btn btn-dark btn-social mx-2" href="#!" aria-label="Bitty Instagram Profile"><i class="fab fa-instagram"></i></a>


### PR DESCRIPTION
## Summary

- **#46** `index.html`: masthead site title changed from `<div>` to `<h1>` — page now has a semantic heading for screen readers and SEO
- **#21** `_includes/header.html`: navbar logo gets `alt="Nelson Farm and Grill"` and explicit `width`/`height` attributes
- **#22** `_includes/recipe-card.html`: caption subheading color changed from Bootstrap `text-muted` (#6c757d gray) to `rgba(255,255,255,0.9)` — meets WCAG AA contrast on the dark overlay background
- **#48** `_includes/recipe-card.html`: removed `style=` inline attributes from `.portfolio-caption` and `.portfolio-caption-heading`; styles now live in `css/styles.css`
- **#14** `css/styles.css`: dropped `#portfolio` scope from all `.portfolio-item` rules — hover overlay now triggers correctly in `#starters`, `#mains`, etc.
- **#47** `css/styles.css`: hover overlay color changed from `rgba(255,204,255,0.8)` (pinkish magenta) to `rgba(255,200,0,0.8)` (brand gold `#ffc800`)
- **#49** `_includes/recipe-card.html`: added `width="600" height="450"` to recipe card images (all portfolio images are 600×450)
- **#49** `index.html`: added `width="500" height="500"` to all four team member images (all team images are 500×500)

Closes #14, closes #21, closes #22, closes #46, closes #47, closes #48, closes #49