### PR TITLE
Fix: navbar logo stretched — add width: auto to brand img CSS rules

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -11359,6 +11359,7 @@ p {
 }
 #mainNav .navbar-brand img {
   height: 2rem;
+  width: auto;
 }
 #mainNav .navbar-nav .nav-item .nav-link {
   font-family: "Montserrat", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
@@ -11384,6 +11385,7 @@ p {
   }
   #mainNav .navbar-brand img {
     height: 4rem;
+    width: auto;
     transition: height 0.3s ease-in-out;
   }
   #mainNav.navbar-shrink {
@@ -11397,6 +11399,7 @@ p {
   #mainNav.navbar-shrink .navbar-brand svg,
 #mainNav.navbar-shrink .navbar-brand img {
     height: 2rem;
+    width: auto;
   }
   #mainNav .navbar-nav .nav-item {
     margin-right: 1rem;


### PR DESCRIPTION
## Summary

- **#54** `css/styles.css`: add `width: auto` to all three `#mainNav .navbar-brand img` rules (mobile, desktop, shrink states)

`css/styles.css` constrains the navbar logo to `height: 2rem` / `4rem` but had no `width` rule. PR #53 added `width="498"` as an HTML attribute to `_includes/header.html`. The browser applied the CSS height constraint (32–64px) while rendering the HTML `width` attribute literally (498px), producing a horizontally stretched oval. Adding `width: auto` overrides the HTML attribute and restores proportional scaling from the CSS-constrained height.

Closes #54