### PR TITLE
Fix: populate meta description from site.description

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-        <meta name="description" content="" />
+        <meta name="description" content="{{ site.description }}" />
         <meta name="author" content="" />
         <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
         <!-- Favicon-->


### PR DESCRIPTION
Fixes #24

Changes `content=""` to `content="{{ site.description }}"` in `_layouts/default.html` so the meta description tag uses the value from `_config.yml`.

Single-line change. No other files modified.