### PR TITLE
Fix: update Google Fonts to v2 API with display=swap

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,8 +11,8 @@
         <!-- Font Awesome icons (free version)-->
         <script src="https://use.fontawesome.com/releases/v6.1.0/js/all.js" crossorigin="anonymous"></script>
         <!-- Google fonts-->
-        <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css" />
-        <link href="https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700" rel="stylesheet" type="text/css" />
+        <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet" />
+        <link href="https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@100;300;400;700&display=swap" rel="stylesheet" />
         <!-- Core theme CSS (includes Bootstrap)-->
         <link href="{{ '/css/styles.css' | relative_url }}" rel="stylesheet" />
     </head>


### PR DESCRIPTION
Fixes #32

Updates Google Fonts from deprecated v1 API to v2 with display=swap parameter. Preserves all font weights (Montserrat 400,700 and Roboto Slab 100,300,400,700). Eliminates render-blocking FOUT.

Two lines changed in _layouts/default.html. No other files modified.