### PR TITLE
Fix: update Font Awesome to v6.5 CSS from cdnjs

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
         <!-- Favicon-->
         <link rel="icon" type="image/x-icon" href="{{ '/assets/img/bear-removebg.png' | relative_url }}" />
         <!-- Font Awesome icons (free version)-->
-        <script src="https://use.fontawesome.com/releases/v6.1.0/js/all.js" crossorigin="anonymous"></script>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" />
         <!-- Google fonts-->
         <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet" />
         <link href="https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@100;300;400;700&display=swap" rel="stylesheet" />


### PR DESCRIPTION
Fixes #31

Replaces legacy use.fontawesome.com JS loader (v6.1.0) with modern CSS link from cdnjs (v6.5.1). Single line change in _layouts/default.html.