### PR TITLE
Fix: Enforce uniform portfolio tile sizing (Issue #62)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -11457,6 +11457,11 @@ header.masthead .masthead-heading {
   margin-left: auto;
   margin-right: auto;
 }
+.portfolio-item img {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+}
 .portfolio-item .portfolio-link {
   position: relative;
   display: block;


### PR DESCRIPTION
## Summary

Adds CSS constraints to `.portfolio-item img` to enforce uniform tile sizing across all portfolio recipe cards.

## Problem

`pork-butt.jpg` (800×1067, portrait) renders significantly taller than other recipe tile images (~600×450, landscape) because the only CSS applied was `.img-fluid` (`max-width: 100%`), which preserves the original aspect ratio.

## Fix

Added three properties to a new `.portfolio-item img` rule in `css/styles.css`:

- `width: 100%` — fills the tile width
- `aspect-ratio: 4 / 3` — enforces the landscape ratio matching existing tile dimensions (600×450 = 4:3)
- `object-fit: cover` — crops rather than stretches to fill the constrained area

This ensures all tiles render at uniform height regardless of source image dimensions, with center-cropping for non-matching aspect ratios.

## Files Changed

- `css/styles.css` — 5 lines added (new `.portfolio-item img` rule block)

## Testing

- Jekyll build passes with no errors
- Only `css/styles.css` modified
- Existing `.portfolio-item` rules unchanged

Fixes #62