### PR TITLE
fix(family): remove all social links from Family section

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,6 @@ layout: default
                             <img class="mx-auto rounded-circle" src="assets/img/team/ricky.png" alt="Ricky Nelson" width="500" height="500" />
                             <h4>Ricky Nelson</h4>
                             <p class="text-muted">Pops</p>
-                            <a class="btn btn-dark btn-social mx-2" href="https://www.linkedin.com/in/ricky-nelson/" target="_blank" rel="noopener noreferrer" aria-label="Ricky Nelson LinkedIn Profile"><i class="fab fa-linkedin-in"></i></a>
                         </div>
                     </div>
                     <div class="col-lg-3">
@@ -66,7 +65,6 @@ layout: default
                             <img class="mx-auto rounded-circle" src="assets/img/team/sara.jpg" alt="SaraLu" width="500" height="500" />
                             <h4>SaraLu</h4>
                             <p class="text-muted">Lu</p>
-                            <a class="btn btn-dark btn-social mx-2" href="#!" aria-label="SaraLu LinkedIn Profile"><i class="fab fa-linkedin-in"></i></a>
                         </div>
                     </div>
                     <div class="col-lg-3">
@@ -74,7 +72,6 @@ layout: default
                             <img class="mx-auto rounded-circle" src="assets/img/team/bear.jpg" alt="Bear" width="500" height="500" />
                             <h4>Bear</h4>
                             <p class="text-muted">Dooters</p>
-                            <a class="btn btn-dark btn-social mx-2" href="#!" aria-label="Bear Instagram Profile"><i class="fab fa-instagram"></i></a>
                         </div>
                     </div>
                     <div class="col-lg-3">
@@ -82,7 +79,6 @@ layout: default
                             <img class="mx-auto rounded-circle" src="assets/img/team/bitty.jpg" alt="Bitty" width="500" height="500" />
                             <h4>Bitty</h4>
                             <p class="text-muted">Itty Bitty Kitty</p>
-                            <a class="btn btn-dark btn-social mx-2" href="#!" aria-label="Bitty Instagram Profile"><i class="fab fa-instagram"></i></a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
Removes all social link buttons from the Family section per owner directive.

## Changes
Removes social link `<a>` elements from all four team members:
- **Ricky**: removed LinkedIn link (real URL)
- **SaraLu**: removed placeholder LinkedIn link (`#!`)
- **Bear**: removed placeholder Instagram link (`#!`)
- **Bitty**: removed placeholder Instagram link (`#!`)

## Rationale
Owner directive: clean sweep — no social links for any family member. This addresses both the placeholder links (Issue #15) and intentionally removes Ricky's real LinkedIn link as requested.

Fixes #15

---
*Automated fix by JR (Software Engineer) — NFG Swarm Pipeline*