### PR TITLE
fix: UI improvements — navbar, tile text wrap, clickable tiles

### DIFF
--- a/_includes/recipe-card.html
+++ b/_includes/recipe-card.html
@@ -4,12 +4,12 @@
             {% if recipe.images %}
                 <img class="img-fluid" src="{{ recipe.images[0].path | relative_url }}" alt="{{ recipe.images[0].alt }}" width="600" height="450" />
             {% endif %}
+            <div class="portfolio-caption">
+                <div class="portfolio-caption-heading">{{ recipe.title }}</div>
+                {% if recipe.subtitle %}
+                    <div class="portfolio-caption-subheading">{{ recipe.subtitle }}</div>
+                {% endif %}
+            </div>
         </a>
-        <div class="portfolio-caption">
-            <div class="portfolio-caption-heading">{{ recipe.title }}</div>
-            {% if recipe.subtitle %}
-                <div class="portfolio-caption-subheading">{{ recipe.subtitle }}</div>
-            {% endif %}
-        </div>
     </div>
 </div>

--- a/css/styles.css
+++ b/css/styles.css
@@ -11376,7 +11376,7 @@ p {
     padding-top: 1.5rem;
     padding-bottom: 1.5rem;
     border: none;
-    background-color: transparent;
+    background-color: #212529;
     transition: padding-top 0.3s ease-in-out, padding-bottom 0.3s ease-in-out;
   }
   #mainNav .navbar-brand {
@@ -11466,6 +11466,8 @@ header.masthead .masthead-heading {
   position: relative;
   display: block;
   margin: 0 auto;
+  text-decoration: none;
+  cursor: pointer;
 }
 .portfolio-item .portfolio-link .portfolio-hover {
   display: flex;
@@ -11492,11 +11494,14 @@ header.masthead .masthead-heading {
   border-radius: 5px;
 }
 .portfolio-item .portfolio-caption .portfolio-caption-heading {
-  font-size: 1.5rem;
+  font-size: 1.25rem;
   font-family: "Montserrat", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-weight: 700;
   margin-bottom: 0;
   color: #ffc800;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .portfolio-item .portfolio-caption .portfolio-caption-subheading {
   font-style: italic;


### PR DESCRIPTION
## Grouped Issues

- Fixes #66 — Navbar transparent at top of page, hard to read links over background GIF
- Fixes #68 — Butternut Squash Turkey Chili tile text wraps, causing oversized tile
- Fixes #71 — Clicking anywhere on recipe tile should open the modal, not just the image

## Why Grouped

All three issues involve CSS/HTML structure changes to the recipe page UI. They share concerns:
- #66 and #68 are both CSS styling fixes
- #68 and #71 both involve the recipe tile component (`recipe-card.html` / `.portfolio-item`)
- Fixing #71 (clickable tile area) may interact with #68 (tile sizing)

## Scope

- `css/styles.css` — navbar always-solid, tile text sizing
- `_includes/recipe-card.html` — wrap entire tile in clickable area
- Possibly `_layouts/default.html` if navbar JS transition needs removal

## Status

Placeholder PR — implementation will be done by the swarm pipeline (JR).