### PR TITLE
content: Add missing recipe subtitles (fixes #67)

### DIFF
--- a/_recipes/brussels-sprouts-salad.md
+++ b/_recipes/brussels-sprouts-salad.md
@@ -1,6 +1,7 @@
 ---
 layout: recipe
 title: Chopped Brussels Sprouts Salad with Creamy Shallot Dressing
+subtitle: Crispy bacon, pomegranate, and creamy shallot dressing
 category: starters
 prep_time: 20 minutes
 cook_time: 15 minutes

--- a/_recipes/greek-chopped-salad.md
+++ b/_recipes/greek-chopped-salad.md
@@ -1,6 +1,7 @@
 ---
 layout: recipe
 title: Greek Chopped Salad
+subtitle: Fresh, bright, and loaded with Mediterranean flavor
 category: starters
 prep_time: 20 minutes
 servings: 6-8

--- a/_recipes/meringue-cookies.md
+++ b/_recipes/meringue-cookies.md
@@ -1,6 +1,7 @@
 ---
 layout: recipe
 title: Meringue Cookies
+subtitle: Light, crispy, and melt-in-your-mouth sweet
 category: desserts
 prep_time: 20 minutes
 cook_time: 1 hour

--- a/_recipes/simple-salt-brine.md
+++ b/_recipes/simple-salt-brine.md
@@ -1,6 +1,7 @@
 ---
 layout: recipe
 title: Simple Salt Brine
+subtitle: The secret to juicy chicken wings every time
 category: miscellaneous
 prep_time: 5 minutes
 brine_time: 2-3 hours


### PR DESCRIPTION
## Summary

Add the missing `subtitle:` front matter field to 4 recipe files that were missing it, as identified in issue #67.

### Files Changed
- `_recipes/brussels-sprouts-salad.md` — "Crispy bacon, pomegranate, and creamy shallot dressing"
- `_recipes/greek-chopped-salad.md` — "Fresh, bright, and loaded with Mediterranean flavor"
- `_recipes/meringue-cookies.md` — "Light, crispy, and melt-in-your-mouth sweet"
- `_recipes/simple-salt-brine.md` — "The secret to juicy chicken wings every time"

### Details
- Subtitle field positioned after `title:` and before `category:` (matching existing convention)
- Subtitle tone matches existing recipes (short, descriptive, conversational)
- Jekyll build verified — no errors
- No other files modified

Fixes #67