### PR TITLE
fix: shorten Brussels Sprouts recipe title and add subtitle overflow control

### DIFF
--- a/_recipes/brussels-sprouts-salad.md
+++ b/_recipes/brussels-sprouts-salad.md
@@ -1,6 +1,6 @@
 ---
 layout: recipe
-title: Chopped Brussels Sprouts Salad with Creamy Shallot Dressing
+title: Brussels Sprouts Salad with Creamy Shallot Dressing
 subtitle: Crispy bacon, pomegranate, and creamy shallot dressing
 category: starters
 prep_time: 20 minutes
@@ -8,7 +8,7 @@ cook_time: 15 minutes
 servings: 4-6
 images:
   - path: assets/img/portfolio/brussels-sprout-salad-creamy-shallot.jpeg
-    alt: Chopped Brussels Sprouts Salad with Creamy Shallot Dressing
+    alt: Brussels Sprouts Salad with Creamy Shallot Dressing
 ingredients:
   - group: Salad
     items:

--- a/css/styles.css
+++ b/css/styles.css
@@ -11491,6 +11491,9 @@ header.masthead .masthead-heading {
   font-style: italic;
   font-family: "Roboto Slab", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   color: rgba(255, 255, 255, 0.9);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .portfolio-modal .modal-dialog {


### PR DESCRIPTION
## Changes

- Renamed recipe title from "Chopped Brussels Sprouts Salad with Creamy Shallot Dressing" to "Brussels Sprouts Salad with Creamy Shallot Dressing" in `_recipes/brussels-sprouts-salad.md` (title + alt text)
- Added overflow control (`white-space: nowrap; overflow: hidden; text-overflow: ellipsis`) to `.portfolio-caption-subheading` in `css/styles.css` to prevent future tile wrapping inconsistencies

Fixes #79

---
*PR created by JR (Software Engineer) via swarm pipeline*