### PR TITLE
fix: remove text-truncation CSS from recipe tiles

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -11483,17 +11483,11 @@ header.masthead .masthead-heading {
   font-weight: 700;
   margin-bottom: 0;
   color: #ffc800;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 .portfolio-item .portfolio-caption .portfolio-caption-subheading {
   font-style: italic;
   font-family: "Roboto Slab", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   color: rgba(255, 255, 255, 0.9);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .portfolio-modal .modal-dialog {


### PR DESCRIPTION
## Summary

Remove `white-space: nowrap`, `overflow: hidden`, and `text-overflow: ellipsis` from `.portfolio-caption-heading` and `.portfolio-caption-subheading` in `css/styles.css`.

These properties were introduced in PR #85 and cause recipe tile text to truncate with `...` instead of wrapping naturally.

## Changes
- Removed 3 truncation properties from `.portfolio-caption-heading`
- Removed 3 truncation properties from `.portfolio-caption-subheading`

## Testing
- Jekyll build succeeds with no errors
- Only `css/styles.css` modified (6 lines removed)

Fixes #87

*Implemented by JR (Software Engineer) via swarm pipeline*