### PR TITLE
fix: standardize tile caption height for consistent layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -11476,6 +11476,10 @@ header.masthead .masthead-heading {
   text-align: center;
   background-color: rgba(0, 0, 0, 0.5);
   border-radius: 5px;
+  min-height: 5.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 .portfolio-item .portfolio-caption .portfolio-caption-heading {
   font-size: 1.25rem;


### PR DESCRIPTION
Fixes #92

Adds min-height and flexbox centering to `.portfolio-caption` to ensure all recipe tiles render at a consistent height.

## Regression context
- PR #85 added ellipsis rules (caused #87 text truncation)
- PR #91 removed those rules (caused #92 height inconsistency)
- This fix takes a different approach — standardizing the caption container height while allowing text to wrap naturally. No text truncation rules are used.

## Changes
- Added `min-height: 5.5rem` to `.portfolio-item .portfolio-caption` — creates a uniform minimum caption height
- Added `display: flex; flex-direction: column; justify-content: center` — vertically centers caption content
- No text-overflow, white-space:nowrap, or overflow:hidden rules — text wraps naturally