### PR TITLE
Fix: Move Sesame Ginger Dressing to Miscellaneous (#88)

### DIFF
--- a/_recipes/sesame-ginger-dressing.md
+++ b/_recipes/sesame-ginger-dressing.md
@@ -2,7 +2,7 @@
 layout: recipe
 title: Sesame Ginger Salad Dressing
 subtitle: Mix all ingredients. BAM!
-category: starters
+category: miscellaneous
 prep_time: 5 minutes
 servings: 4-6
 images:


### PR DESCRIPTION
Fixes #88

Changes the category for Sesame Ginger Salad Dressing from `starters` to `miscellaneous` in the recipe front matter.

## What changed
- `_recipes/sesame-ginger-dressing.md`: `category: starters` → `category: miscellaneous`

## Verification
- Jekyll build passes with no errors
- Recipe appears under Miscellaneous section
- No other files modified

---
*Implemented by Michael (Engineering Manager) as JR fallback — GPT-5.3-Codex model silent failure (0 tokens, 3rd consecutive cycle).*