### PR TITLE
fix: replace generic card subtexts with descriptive text (#121)

### DIFF
--- a/_recipes/dumpling-lasagna.md
+++ b/_recipes/dumpling-lasagna.md
@@ -1,7 +1,7 @@
 ---
 layout: recipe
 title: Dumpling Lasagna
-subtitle: Category - Fusion Comfort Food
+subtitle: Chinese-Italian fusion with wonton wrappers and savory pork
 category: mains
 prep_time: 45 minutes
 cook_time: 45 minutes

--- a/_recipes/egg-roll-bowl.md
+++ b/_recipes/egg-roll-bowl.md
@@ -1,7 +1,7 @@
 ---
 layout: recipe
 title: Egg Roll in a Bowl
-subtitle: Category - Meal Prep
+subtitle: Deconstructed egg roll — quick, low-carb, and meal-prep ready
 category: mains
 prep_time: 15 minutes
 cook_time: 25 minutes

--- a/_recipes/filet-mignon.md
+++ b/_recipes/filet-mignon.md
@@ -1,7 +1,7 @@
 ---
 layout: recipe
 title: Filet Mignon
-subtitle: Category - Special Occasion
+subtitle: Pan-seared and butter-basted to perfection
 category: mains
 prep_time: 30 minutes
 cook_time: 20 minutes

--- a/_recipes/maple-brined-pork-chops.md
+++ b/_recipes/maple-brined-pork-chops.md
@@ -1,7 +1,7 @@
 ---
 layout: recipe
 title: Maple Brined Pork Chops
-subtitle: Category - Meal Prep
+subtitle: Sweet maple brine meets the Big Green Egg
 category: mains
 prep_time: 4 hours 15 minutes
 cook_time: 15 minutes


### PR DESCRIPTION
## Summary

Replaces generic "Category - X" placeholder subtitles with descriptive phrases for 4 recipe cards.

## Changes

| Recipe | Before | After |
|--------|--------|-------|
| Dumpling Lasagna | Category - Fusion Comfort Food | Chinese-Italian fusion with wonton wrappers and savory pork |
| Egg Roll in a Bowl | Category - Meal Prep | Deconstructed egg roll — quick, low-carb, and meal-prep ready |
| Filet Mignon | Category - Special Occasion | Pan-seared and butter-basted to perfection |
| Maple Brined Pork Chops | Category - Meal Prep | Sweet maple brine meets the Big Green Egg |

## Scope

- 4 files changed, 1 line each (subtitle field only)
- No other front matter or content modifications
- No other files touched

Fixes #121