### PR TITLE
docs: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,77 +1,79 @@
-# NFG
-Meatballs
-Shrimp Scampi
-Beef Wellington
+# Nelson Farm and Grill
 
+A family recipe collection published as a [Jekyll](https://jekyllrb.com/) site on [GitHub Pages](https://rickmanley-nc.github.io/NFG/).
 
-## Create new recipe
-1. Add recipe to relevant `recipes/` directory based on category
-2. Follow template below:
-```
-<div class="modal-content">
-    <div class="close-modal" data-bs-dismiss="modal"><img src="assets/img/close-icon.svg" alt="Close modal" /></div>
-    <div class="container">
-        <div class="row justify-content-center">
-            <div class="col-lg-8">
-                <div class="modal-body">
-                    <!-- Project details-->
-                    <h2 class="text-uppercase">Gold Rush</h2>
-                    <p class="item-intro text-muted">Four Roses, Knob Creek, Bulleit</p>
-                    <img class="img-fluid d-block mx-auto" src="assets/img/portfolio/goldrush.jpg" alt="..." />
-                    <h3 style="text-align:left">Honey Syrup</h3>
-                    <ul style="text-align:left">
-                        <li>1/4 cup honey</li>
-                        <li>1/4 cup water</li>
-                    </ul>
-                    <h3 style="text-align:left">Cocktail</h3>
-                    <ul style="text-align:left">
-                        <li>2 ounces bourbon</li>
-                        <li>3/4 ounce lemon juice</li>
-                        <li>1/2 ounce honey syrup</li>
-                        <li>Lemon peel/slice for garnish</li>
-                    </ul>
-                    <h3 style="text-align:left">Steps</h3>
-                    <ol style="text-align:left">
-                        <li>Make honey syrup</li>
-                        <li>Fill a cocktail shaker with ice. Add bourbon, lemon juice, and honey syrup. Cover and shake vigorously, about 15 seconds.</li>
-                        <li>Strain into an ice-filled rocks glass and garnish with a lemon twist.</li>
-                        </ol>
-                    <button class="btn btn-primary btn-xl text-uppercase" data-bs-dismiss="modal" type="button">
-                        <i class="fas fa-xmark me-1"></i>
-                        Back
-                    </button>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
+## Site
+
+**Live site:** https://rickmanley-nc.github.io/NFG/
+
+## Recipe Collection
+
+32 recipes across 6 categories:
+
+| Category | Count |
+|---|---|
+| Mains | 7 |
+| Starters | 6 |
+| Smoked | 6 |
+| Miscellaneous | 5 |
+| Desserts | 4 |
+| Cocktails | 4 |
+
+### Recent Additions
+
+- Red Chile Rub Steak
+- BB's Spaghetti Sauce
+- Swiss Chocolate Cake
+- Smoked Prime Rib
+
+## How It Works
+
+Recipes are stored as Markdown files in `_recipes/` with YAML front matter. Jekyll builds them into a browsable site using the `recipe` layout.
+
+### Front Matter Fields
+
+```yaml
+layout: recipe
+title: Recipe Title
+subtitle: Short descriptive subtitle
+category: mains       # mains | starters | smoked | cocktails | desserts | miscellaneous
+prep_time: X minutes
+cook_time: X minutes
+servings: X
+images:
+  - path: assets/img/portfolio/recipe-name.jpg
+    alt: Recipe Title
+ingredients:
+  - group: Group Name
+    items:
+      - item: ingredient name
+        amount: 1
+        unit: cup
+instructions:
+  - group: Group Name
+    steps:
+      - step: "Instruction step"
+notes: "Optional notes."
+equipment:
+  - Equipment item
 ```
 
-3. Modify Grid section and Modal section in `index.html`
-Grid template (currently 3 items per row):
+## Adding a Recipe
+
+1. Copy `templates/recipe-template.md` to `_recipes/<recipe-name>.md`
+2. Fill in all front matter fields
+3. Add a recipe image to `assets/img/portfolio/`
+4. Open a pull request — the swarm pipeline will review and merge
+
+## Development
+
+```bash
+bundle install
+bundle exec jekyll serve
 ```
-                    <div class="col-lg-4 col-sm-6 mb-4">
-                        <!-- Cocktails 1-->
-                        <div class="portfolio-item">
-                            <a class="portfolio-link" data-bs-toggle="modal" href="#cocktailsModal1">
-                                <div class="portfolio-hover">
-                                    <div class="portfolio-hover-content"><i class="fas fa-plus fa-3x"></i></div>
-                                </div>
-                                <img class="img-fluid" src="assets/img/portfolio/goldrush.jpg" alt="..." />
-                            </a>
-                            <div class="portfolio-caption">
-                                <div class="portfolio-caption-heading text-black">Gold Rush</div>
-                                <div class="portfolio-caption-subheading text-muted">Bourbon, honey syrup, and lemon juice</div>
-                            </div>
-                        </div>
-                    </div>
-```
-Modal template:
-```
-        <div class="portfolio-modal modal fade bg-secondary bg-gradient" id="cocktailsModal1" tabindex="-1" role="dialog" aria-hidden="true">
-            <div class="modal-dialog">
-                <!-- the include file -->
-                <div w3-include-html="recipes/1_cocktails_and_mocktails/goldrush.html"></div>
-            </div>
-        </div>
-```
+
+Site runs at `http://localhost:4000/NFG/`.
+
+## Pipeline
+
+This repository is managed by the [swarm-repo](https://github.com/rickmanley-nc/swarm-repo) AI agent pipeline. Issues are triaged, implemented, tested, and merged automatically. To request a new recipe or change, open a GitHub issue.


### PR DESCRIPTION
Updates README.md to reflect the current state of the Nelson Farm and Grill recipe site.

**Removed:** stale Bootstrap modal HTML, placeholder recipe list (Meatballs, Shrimp Scampi, Beef Wellington), and pre-Jekyll grid instructions.

**Added:** live site URL, 32 recipes across 6 categories with counts, recent additions (Red Chile Rub Steak, BB's Spaghetti Sauce, Swiss Chocolate Cake, Smoked Prime Rib), contributor workflow with front matter reference, local dev instructions, and swarm pipeline section.

Fixes #137